### PR TITLE
Change Base Image to Python:3.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,3 @@
-FROM python:3.7-alpine
+FROM python:3.7
 
-RUN apk add --no-cache bash \
-                       gcc \
-                       gettext \
-                       git \
-                       jpeg-dev \
-                       libffi-dev \
-                       libmagic \
-                       musl-dev \
-                       openssh-client \
-                       openssl-dev \
-                       postgresql-dev \
-                       zlib-dev \
-                       && pip install pipenv
+RUN apt-get update && apt-get install -y gettext && pip install pipenv

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 FROM python:3.7-alpine
 
-ENV PIPENV_VENV_IN_PROJECT=enabled
 RUN apk add --no-cache bash \
                        gcc \
                        gettext \


### PR DESCRIPTION
BE dependencies are not cached anymore for some reason in our pipelines.

Currently our virtual environment creation path is overridden using an env var. This leads to the creation of .venv file in PROJECT ROOT. And the we used to cache this folder accordingly in pipeline.

Since this isnt working anymore, this PR is an experiment to see if using default pipenv virtualenv location works.

Before merging this PR:
- A new image with new version is to be built and published to chemondis's docker hub
- Then a new PR with the new image version is to be created in Chemondis marketplace REPO
- If and only if the caching works, then this PR is to be merged. 
